### PR TITLE
feat(workflow): add SDK Parity Dispatch workflow

### DIFF
--- a/.github/workflows/sdk-parity-dispatch.yml
+++ b/.github/workflows/sdk-parity-dispatch.yml
@@ -1,0 +1,17 @@
+name: SDK Parity Dispatch
+
+on:
+  push:
+    paths:
+      - "src/**"
+      - "Cargo.toml"
+  pull_request:
+    paths:
+      - "src/**"
+      - "Cargo.toml"
+  workflow_dispatch:
+
+jobs:
+  parity-dispatch:
+    uses: tapsilat/tapsilat-sdk-parity/.github/workflows/reusable-sdk-parity-dispatch.yml@main
+    secrets: inherit


### PR DESCRIPTION
- Introduced a new GitHub Actions workflow for SDK parity dispatch.
- Configured to trigger on push and pull request events for specific paths.
- Utilizes a reusable workflow from tapsilat/tapsilat-sdk-parity.